### PR TITLE
Move blog  to heroku + ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
 _import
 .DS_Store
-Gemfile.lock
+.asset-cache
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+gem "rake"
 gem "jekyll"
+gem "jekyll-assets"
+gem "jekyll-paginate"
 gem "RedCloth"
 gem "rdiscount"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+ruby "2.2.2"
 source "https://rubygems.org"
 
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.2.9)
+    addressable (2.3.8)
+    colorator (0.1)
+    concurrent-ruby (1.0.0)
+    fastimage (1.8.1)
+      addressable (~> 2.3, >= 2.3.5)
+    ffi (1.9.10)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-assets (2.0.3)
+      fastimage (~> 1.8)
+      jekyll (~> 3.0)
+      sprockets (~> 3.3)
+      sprockets-helpers (~> 1.2)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    rack (1.6.4)
+    rake (10.4.2)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rdiscount (2.1.8)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.19)
+    sprockets (3.5.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-helpers (1.2.1)
+      sprockets (>= 2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth
+  jekyll
+  jekyll-assets
+  jekyll-paginate
+  rake
+  rdiscount
+
+BUNDLED WITH
+   1.10.6

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Corey Donohoe
+Copyright (c) 2000-2016 Corey Donohoe
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/boot

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bin/boot

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is the data for my personal website
 
 This is the combination of two older blog dumps that I have from 2000 - 2009.  all of my atmos.org posts combined.
 
-It is automatically transformed by Jekyll into a static site whenever I push this repository to GitHub.
+It is automatically transformed by Jekyll into a static site on Heroku whenever I push this repository to GitHub.
 
 License
 =======

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "rubygems"
+require "rake"
+
+namespace :assets do
+  desc "Precompile Jekyll site"
+  task :precompile do
+    sh "jekyll build"
+  end
+end

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ lsi:         false
 port:        4000
 highligher:  true
 markdown:    rdiscount
-permalink:   /:year/:month/:day/:title
+permalink:   date
 email: "atmos@atmos.org"
 url: "https://atmos.org"
 exclude: [vendor]

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ markdown:    rdiscount
 permalink:   /:year/:month/:day/:title
 email: "atmos@atmos.org"
 url: "https://atmos.org"
+exclude: [vendor]
 
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -4,5 +4,8 @@ port:        4000
 highligher:  true
 markdown:    rdiscount
 permalink:   date
+email: "atmos@atmos.org"
+url: "https://atmos.org"
+
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ lsi:         false
 port:        4000
 highligher:  true
 markdown:    rdiscount
-permalink:   date
+permalink:   /:year/:month/:day/:title
 email: "atmos@atmos.org"
 url: "https://atmos.org"
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "atmos' blog",
+  "description": "This is the blog of Corey Donohoe",
+  "website": "https://atmos.org",
+  "repository": "https://github.com/atmos/atmos.github.io",
+  "env": {
+    "JEKYLL_ENV": {
+      "description": "Jekyll Environment. It affects asset compilation. Details see https://github.com/jekyll/jekyll-assets#configuration.",
+      "value": "production"
+    }
+  },
+  "buildpacks": [
+    {
+
+      "url": "https://github.com/hone/heroku-buildpack-static.git"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -3,5 +3,5 @@ layout: default
 title: atmos.org ~ Corey Donohoe on the Internet
 ---
 
-<img src="http://f.cl.ly/items/2i3O350d3k0o3L2D401M/Image%202013.10.20%207%3A47%3A06%20PM.png" alt="color photo ftl" />
+<img src="https://cloud.githubusercontent.com/assets/38/11616757/3d1ab7c6-9c38-11e5-9133-3c756b6f4c14.png" alt="color photo ftl" />
 <p>Mom calls me Corey, friends call me atmos.</p>

--- a/static.json
+++ b/static.json
@@ -1,0 +1,6 @@
+{
+  "root": "_site/",
+  "https_only": true,
+  "clean_urls": true,
+  "error_page": "404.html"
+}


### PR DESCRIPTION
I setup @letsencrypt with heroku's ssl endpoint addon so I can serve my person website over ssl.  Here are the steps.

* Boot an ubuntu ec2 instance and get the IP
* Update your DNS settings for the IP in question to the IP of the ec2 instance
* Login to the ec2 instances and install git, `apt-get install git`
* Clone [letsencrypt/letsencrypt](https://github.com/letsencrypt/letsencrypt).
* Run `./letsencrypt-auto certonly --standalone --email me@mydomain.com -d atmos.org -d www.atmos.org -d othedomains.atmos.org
* Copy the contents of `/etc/letsencrypt/live` to your local system.
* Shut down the ec2 instance.
* Upload the certs to a heroku [ssl endpoint](https://devcenter.heroku.com/articles/ssl-endpoint#provision-the-add-on), `heroku certs:add atmos.org/fullchain.pem atmos.org/privkey.pem`
* Setup jekyll to use the heroku buildpack static `heroku buildpacks:set https://github.com/hone/heroku-buildpack-static.git`
* Insure the ruby buildpack in front of it. `heroku buildpacks:add --index 1 heroku/ruby`
* Push the changes up to your heroku remote.

